### PR TITLE
Following up on Vlad's advice. 

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@heygen/liveavatar-web-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
+  "files": [
+    "lib",
+    "dist",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
@@ -24,6 +31,8 @@
   "main": "./lib/index.cjs.js",
   "module": "./lib/index.esm.js",
   "types": "./lib/index.d.ts",
+  "unpkg": "./dist/index.umd.js",
+  "jsdelivr": "./dist/index.umd.js",
   "type": "module",
   "scripts": {
     "build": "rollup -c",

--- a/packages/js-sdk/rollup.config.js
+++ b/packages/js-sdk/rollup.config.js
@@ -4,6 +4,7 @@ import typescript from "@rollup/plugin-typescript";
 import json from "@rollup/plugin-json";
 
 export default [
+  // Unbundled builds for npm (lib/)
   {
     input: "src/index.ts",
     output: [
@@ -16,7 +17,48 @@ export default [
         format: "esm",
       },
     ],
-    plugins: [json(), resolve(), commonjs(), typescript()],
-    external: ["livekit-client", "webrtc-issue-detector"],
+    plugins: [
+      json(),
+      resolve(),
+      commonjs(),
+      typescript({
+        declaration: true,
+        declarationDir: "lib",
+        rootDir: "src",
+      }),
+    ],
+    external: [
+      "livekit-client",
+      "webrtc-issue-detector",
+      "events",
+      "typed-emitter",
+    ],
+  },
+  // Bundled builds for browser/CDN (dist/)
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: "dist/index.umd.js",
+        format: "umd",
+        name: "LiveAvatarSDK", // Global variable name for browser
+        sourcemap: true,
+      },
+      {
+        file: "dist/index.esm.js",
+        format: "esm",
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      json(),
+      resolve({ browser: true }), // Bundle dependencies
+      commonjs(),
+      typescript({
+        declaration: false, // No need for .d.ts in bundled version
+        rootDir: "src",
+      }),
+    ],
+    // No external dependencies - bundle everything
   },
 ];


### PR DESCRIPTION
## Proposed changes

Original feedback from Vlad
> There are some issues we should probably discuss.
> 1. If you take a look at the screenshot, there’re some files we should probably exclude from publishing (tsconfig, eslintconfig, src folder, .turbo folder, etc.) in order to keep sdk light-weight.
> 2. I’m not sure whether license file should be on top of our turborepo or in sdk package itself (right now it’s not included in compiled package as you can see).
> 3. Potentially, we should have lib and dist folders in compiled package (lib for unbundled version, dist for bundled version).
> 4. Not sure where we should have CHANGELOG and meaningful README. I assume they should be in js-sdk package folder, because repo-level readme/changelog files don’t appear on npm page and don’t appear on compiled package

This PR fixes 1 + 3 via code configuration. We will filter out the changes needed for development. It also configures the rollup file to also create lib + dist folders in the compiled packages. 

As for follow ups - I've already moved the README through so that won't be an issue. The CHANGELOG I'll need to follow up on. Punting for now as its not a high pri thing to do before GA. 