### PR TITLE
Fix: api error message

### DIFF
--- a/packages/js-sdk/src/LiveAvatarSession/SessionApiClient.ts
+++ b/packages/js-sdk/src/LiveAvatarSession/SessionApiClient.ts
@@ -4,7 +4,7 @@ import { SessionInfo } from "./types";
 const DEFAULT_ERROR_CODE = 500;
 const SUCCESS_CODE = 1000;
 
-class SessionApiError extends Error {
+export class SessionApiError extends Error {
   errorCode: number;
   status: number | null = null;
 

--- a/packages/js-sdk/src/LiveAvatarSession/index.ts
+++ b/packages/js-sdk/src/LiveAvatarSession/index.ts
@@ -1,3 +1,4 @@
 export * from "./LiveAvatarSession";
 export * from "./types";
 export * from "./events";
+export * from "./SessionApiClient";

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -2,7 +2,11 @@
 export { LiveAvatarSession } from "./LiveAvatarSession";
 
 // types
-export type { SessionConfig, SessionInfo } from "./LiveAvatarSession";
+export type {
+  SessionConfig,
+  SessionInfo,
+  SessionApiError,
+} from "./LiveAvatarSession";
 export type { VoiceChat, VoiceChatConfig } from "./VoiceChat";
 
 // enums


### PR DESCRIPTION
## Proposed changes

Fix API error handling. Error message field should be on top level of response body instead of in response's body.
