### PR TITLE
[LA-484] Show mic control in SDK demo

### DIFF
--- a/apps/demo/src/components/LiveAvatarSession.tsx
+++ b/apps/demo/src/components/LiveAvatarSession.tsx
@@ -7,6 +7,7 @@ import {
   useTextChat,
   useVoiceChat,
   useChatHistory,
+  useMicrophoneDevices,
 } from "../liveavatar";
 import { SessionState, VoiceChatConfig } from "@heygen/liveavatar-web-sdk";
 import { useAvatarActions } from "../liveavatar/useAvatarActions";
@@ -59,7 +60,8 @@ const ActionButton: React.FC<{
 const LiveAvatarSessionComponent: React.FC<{
   mode: SessionMode;
   onSessionStopped: () => void;
-}> = ({ mode, onSessionStopped }) => {
+  hasVoiceChat: boolean;
+}> = ({ mode, onSessionStopped, hasVoiceChat }) => {
   const [message, setMessage] = useState("");
   const {
     sessionState,
@@ -84,6 +86,8 @@ const LiveAvatarSessionComponent: React.FC<{
     stopPushToTalk,
     error: voiceChatError,
   } = useVoiceChat();
+
+  const { devices, selectedDeviceId, selectDevice } = useMicrophoneDevices();
 
   const avatarActionsMode = mode === "FULL_PTT" ? "FULL" : mode;
   const { interrupt, repeat, startListening, stopListening } =
@@ -295,6 +299,24 @@ const LiveAvatarSessionComponent: React.FC<{
           </p>
         )}
 
+        {/* Microphone Selection */}
+        {hasVoiceChat && devices.length > 1 && (
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-gray-400">Microphone:</label>
+            <select
+              value={selectedDeviceId ?? ""}
+              onChange={(e) => selectDevice(e.target.value)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 text-white text-sm border border-white/10 focus:outline-none focus:border-white/30 transition-colors"
+            >
+              {devices.map((device) => (
+                <option key={device.deviceId} value={device.deviceId}>
+                  {device.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Voice Chat */}
         {mode === "FULL" && (
           <div className="flex items-center gap-2">
@@ -424,6 +446,7 @@ export const LiveAvatarSession: React.FC<{
       <LiveAvatarSessionComponent
         mode={mode}
         onSessionStopped={onSessionStopped}
+        hasVoiceChat={!!voiceChatConfig}
       />
     </LiveAvatarContextProvider>
   );

--- a/apps/demo/src/liveavatar/index.ts
+++ b/apps/demo/src/liveavatar/index.ts
@@ -4,3 +4,4 @@ export * from "./useChatHistory";
 export * from "./useSession";
 export * from "./useVoiceChat";
 export * from "./useTextChat";
+export * from "./useMicrophoneDevices";

--- a/apps/demo/src/liveavatar/useMicrophoneDevices.ts
+++ b/apps/demo/src/liveavatar/useMicrophoneDevices.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useVoiceChat } from "./useVoiceChat";
+
+export interface MicrophoneDevice {
+  deviceId: string;
+  label: string;
+}
+
+export function useMicrophoneDevices() {
+  const [devices, setDevices] = useState<MicrophoneDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const { setDevice } = useVoiceChat();
+  const mountedRef = useRef(true);
+  const selectRequestRef = useRef(0);
+
+  const selectedDeviceIdRef = useRef(selectedDeviceId);
+  selectedDeviceIdRef.current = selectedDeviceId;
+
+  const enumerate = useCallback(async () => {
+    try {
+      const allDevices = await navigator.mediaDevices.enumerateDevices();
+      const mics = allDevices
+        .filter((d) => d.kind === "audioinput" && d.deviceId !== "default")
+        .map((d) => ({
+          deviceId: d.deviceId,
+          label: d.label || `Microphone ${d.deviceId.slice(0, 4)}`,
+        }));
+
+      if (!mountedRef.current) return;
+
+      setDevices(mics);
+
+      const prev = selectedDeviceIdRef.current;
+      let nextDeviceId: string | null = null;
+
+      if (!prev) {
+        nextDeviceId = mics[0]?.deviceId ?? null;
+      } else if (!mics.some((m) => m.deviceId === prev)) {
+        nextDeviceId = mics[0]?.deviceId ?? null;
+      }
+
+      if (nextDeviceId && nextDeviceId !== prev) {
+        setSelectedDeviceId(nextDeviceId);
+        await setDevice({ exact: nextDeviceId });
+      }
+    } catch {
+      // enumerateDevices failed — leave devices empty
+    }
+  }, [setDevice]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    enumerate();
+
+    navigator.mediaDevices.addEventListener("devicechange", enumerate);
+    return () => {
+      mountedRef.current = false;
+      navigator.mediaDevices.removeEventListener("devicechange", enumerate);
+    };
+  }, [enumerate]);
+
+  const selectDevice = useCallback(
+    async (deviceId: string) => {
+      const requestId = ++selectRequestRef.current;
+      const result = await setDevice({ exact: deviceId });
+      if (
+        result &&
+        mountedRef.current &&
+        selectRequestRef.current === requestId
+      ) {
+        setSelectedDeviceId(deviceId);
+      }
+    },
+    [setDevice],
+  );
+
+  return { devices, selectedDeviceId, selectDevice };
+}

--- a/apps/demo/src/liveavatar/useVoiceChat.ts
+++ b/apps/demo/src/liveavatar/useVoiceChat.ts
@@ -46,6 +46,13 @@ export const useVoiceChat = () => {
     return voiceChatState === VoiceChatState.ACTIVE;
   }, [voiceChatState]);
 
+  const setDevice = useCallback(
+    async (constraints: ConstrainDOMString) => {
+      return sessionRef.current.voiceChat.setDevice(constraints);
+    },
+    [sessionRef],
+  );
+
   const startPushToTalk = useCallback(async () => {
     return await sessionRef.current.voiceChat.startPushToTalk();
   }, [sessionRef]);
@@ -59,6 +66,7 @@ export const useVoiceChat = () => {
     unmute,
     start,
     stop,
+    setDevice,
     isLoading,
     isActive,
     isMuted,


### PR DESCRIPTION
## Proposed changes

Summary

  - Ported useMicrophoneDevices hook from orion embed app — enumerates audio input devices, listens for hardware changes, and
  handles device unplugging with fallback
  - Added setDevice method to useVoiceChat hook to expose the SDK's device switching capability
  - Added a mic dropdown selector in the session controls, visible when voice chat is enabled (voiceChatConfig is truthy) and 2+
  microphone devices are detected

  Test plan

  - Start a Full Mode session with multiple microphones connected — verify dropdown appears
  - Switch between microphones — verify audio input changes
  - Unplug the active microphone — verify fallback to first available device
  - Start a session with a single microphone — verify no dropdown is shown
  - Start a Lite Mode session (no voiceChatConfig) — verify no dropdown is shown
  
  Screenshots:
  * When only one mic is available (no selection visible):
  
<img width="1719" height="1074" alt="Screenshot 2026-04-06 at 1 44 59 PM" src="https://github.com/user-attachments/assets/d68d1a7f-bcd6-4e8a-80c3-c9dc39910cc9" />

* when 2+ mics available:

<img width="664" height="300" alt="Screenshot 2026-04-06 at 1 45 40 PM" src="https://github.com/user-attachments/assets/fc409b8b-6dbc-4678-a9b6-5eddb2acd322" />
<img width="665" height="348" alt="Screenshot 2026-04-06 at 1 45 36 PM" src="https://github.com/user-attachments/assets/a5fffcba-b0c9-4fd9-99e1-ff8776cd81b8" />
