### PR TITLE
fix(LITE): base64-encode agent.speak audio chunks

### DIFF
--- a/packages/js-sdk/src/LiveAvatarSession/LiveAvatarSession.test.ts
+++ b/packages/js-sdk/src/LiveAvatarSession/LiveAvatarSession.test.ts
@@ -326,6 +326,7 @@ describe("LiveAvatarSession command events", () => {
     const sendData = testContext.wsInstance.send.mock.calls[0][0];
     const parsedSendData = JSON.parse(sendData);
     expect(parsedSendData.type).toEqual("agent.speak");
+    expect(parsedSendData.audio).toEqual(btoa("test"));
     const lastEvent =
       testContext.wsInstance.send.mock.calls[
         testContext.wsInstance.send.mock.calls.length - 1

--- a/packages/js-sdk/src/LiveAvatarSession/LiveAvatarSession.ts
+++ b/packages/js-sdk/src/LiveAvatarSession/LiveAvatarSession.ts
@@ -688,7 +688,7 @@ export class LiveAvatarSession extends (EventEmitter as new () => TypedEmitter<
             JSON.stringify({
               type: "agent.speak",
               event_id: event_id,
-              audio: audioChunk,
+              audio: btoa(audioChunk),
             }),
           );
         }


### PR DESCRIPTION
## Proposed changes

`repeatAudio()` in LITE mode is currently broken end-to-end: the SDK sends raw "binary string" PCM, but the LiveAvatar server expects base64-encoded PCM 16-bit 24 kHz mono. The server rejects every chunk with

```json
{ "type": "error",
  "error": { "type": "invalid_request_error", "message": "invalid base64 audio data" } }
```

These error events are silently dropped because `handleWebSocketMessage` only forwards `agent.speak_started` / `agent.speak_ended` — so callers see no lip-sync, no audio, and no `AVATAR_SPEAK_STARTED` / `AVATAR_SPEAK_ENDED` events. This matches the [LITE-mode events docs](https://docs.liveavatar.com/docs/lite-mode/events) which say the wire format is base64.

This PR `btoa()`s each audio chunk inside `sendCommandEventToWebSocket` (one line). `repeatAudio(audio: string)`'s public contract — "raw 16-bit signed PCM" as a binary string — is unchanged; the encoding now happens inside the SDK on the way out, where it always belonged.

### Why this is the right place to fix it

`splitPcm24kStringToChunks` operates on raw PCM bytes (it slices on byte boundaries — 19200 / 48000 bytes per chunk). Doing `btoa` *after* chunking keeps that logic correct; doing it before would force callers to pass base64 *and* would break the chunk-size math.

### Testing

Extended the existing `"sends speak audio command event via web socket"` test to assert the `audio` field equals `btoa(input)`. Full suite: `102 passed (102)`. Lint clean.

I verified the fix end-to-end against a real LITE session: `AVATAR_SPEAK_STARTED` / `AVATAR_SPEAK_ENDED` fire as expected and the avatar lip-syncs correctly.

Fixes #92.