### PR TITLE
Make basic demo configurable via env vars and deployable to Vercel

### DIFF
--- a/apps/demo/.env.example
+++ b/apps/demo/.env.example
@@ -1,0 +1,19 @@
+# LiveAvatar API (required)
+API_KEY=your-liveavatar-api-key
+API_URL=https://api.liveavatar.com
+
+# For the client-side SDK to reach the API
+NEXT_PUBLIC_API_URL=https://api.liveavatar.com
+
+# Sandbox mode — leave true unless you have a production API key
+IS_SANDBOX=true
+
+# Defaults used by FULL mode sessions (optional, sensible defaults built in)
+DEFAULT_AVATAR_ID=dd73ea75-1218-4ef3-92ce-606d5f7fbc0a
+DEFAULT_VOICE_ID=c2527536-6d1f-4412-a643-53a3497dada9
+DEFAULT_CONTEXT_ID=5b9dba8a-aa31-11f0-a6ee-066a7fa2e369
+DEFAULT_LANGUAGE=en
+
+# LITE mode only (optional)
+ELEVENLABS_API_KEY=
+OPENAI_API_KEY=

--- a/apps/demo/.gitignore
+++ b/apps/demo/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -10,6 +10,30 @@ For background swapping / chroma key, see [`apps/bg-removal-demo`](../bg-removal
 
 Next.js, TailwindCSS, pnpm.
 
+## Configuration
+
+Copy the example env file and set your LiveAvatar API key:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable              | Required | Default                      | Description                                                       |
+| --------------------- | -------- | ---------------------------- | ----------------------------------------------------------------- |
+| `API_KEY`             | Yes      | —                            | Your LiveAvatar API key (server-side only, never sent to browser) |
+| `API_URL`             | No       | `https://api.liveavatar.com` | LiveAvatar API base URL (server-side)                             |
+| `NEXT_PUBLIC_API_URL` | No       | `https://api.liveavatar.com` | API base URL used by the client-side SDK                          |
+| `IS_SANDBOX`          | No       | `true`                       | Set to `false` only if you have a production API key              |
+| `DEFAULT_AVATAR_ID`   | No       | built-in demo avatar         | Avatar used for FULL mode sessions                                |
+| `DEFAULT_VOICE_ID`    | No       | built-in demo voice          | Voice used for FULL mode sessions                                 |
+| `DEFAULT_CONTEXT_ID`  | No       | built-in demo context        | Context used for FULL mode sessions                               |
+| `DEFAULT_LANGUAGE`    | No       | `en`                         | Session language                                                  |
+| `ELEVENLABS_API_KEY`  | No       | —                            | Only for LITE mode / ElevenLabs agent flows                       |
+| `OPENAI_API_KEY`      | No       | —                            | Only for LITE mode chat completion                                |
+
+Sandbox mode is on by default. If starting a session fails with an authorization or
+plan-related error, try `IS_SANDBOX=false` (production keys) or vice versa.
+
 ## Run
 
 From the monorepo root:
@@ -27,3 +51,25 @@ pnpm dev
 ```
 
 Open <http://localhost:3001>.
+
+## Deploy to Vercel
+
+This app lives in a pnpm/Turborepo monorepo and depends on the workspace package
+`@heygen/liveavatar-web-sdk`, which must be built before `next build`. The committed
+`vercel.json` pins the correct build command (`pnpm turbo run build --filter=demo`),
+so Turborepo builds the SDK first.
+
+1. Push your fork to GitHub.
+2. On [vercel.com](https://vercel.com), choose **Add New… → Project** and import your fork.
+3. Set **Root Directory** to `apps/demo`. Keep "Include source files outside of the
+   Root Directory" enabled (it's the default) so the workspace SDK is available.
+4. Framework preset should auto-detect as Next.js; the build command comes from
+   `vercel.json`. Use Node.js 22.x (the repo requires Node >= 22).
+5. Add environment variables:
+   - `API_KEY` — your LiveAvatar API key (required)
+   - `NEXT_PUBLIC_API_URL` — `https://api.liveavatar.com`
+   - `IS_SANDBOX` — `true` (default) or `false` for production keys
+6. Deploy.
+
+If a session fails after deploying, check the Vercel function logs for the
+`/api/start-session` route — missing or invalid env vars surface there.

--- a/apps/demo/app/api/secrets.ts
+++ b/apps/demo/app/api/secrets.ts
@@ -1,17 +1,21 @@
-export const API_KEY = "YOUR_API_KEY";
-export const API_URL = "https://api.liveavatar.com";
-export const AVATAR_ID = "dd73ea75-1218-4ef3-92ce-606d5f7fbc0a";
+export const API_KEY = process.env.API_KEY ?? "";
+export const API_URL = process.env.API_URL ?? "https://api.liveavatar.com";
+export const AVATAR_ID =
+  process.env.DEFAULT_AVATAR_ID ?? "dd73ea75-1218-4ef3-92ce-606d5f7fbc0a";
 
 // When true, we will call everything in Sandbox mode.
 // Useful for integration and development.
-export const IS_SANDBOX = true;
+// Env vars are strings: any value other than "false" keeps sandbox on.
+export const IS_SANDBOX = process.env.IS_SANDBOX !== "false";
 
 // FULL MODE Customizations
 // Wayne's avatar voice and context
-export const VOICE_ID = "c2527536-6d1f-4412-a643-53a3497dada9";
-export const CONTEXT_ID = "5b9dba8a-aa31-11f0-a6ee-066a7fa2e369";
-export const LANGUAGE = "en";
+export const VOICE_ID =
+  process.env.DEFAULT_VOICE_ID ?? "c2527536-6d1f-4412-a643-53a3497dada9";
+export const CONTEXT_ID =
+  process.env.DEFAULT_CONTEXT_ID ?? "5b9dba8a-aa31-11f0-a6ee-066a7fa2e369";
+export const LANGUAGE = process.env.DEFAULT_LANGUAGE ?? "en";
 
 // LITE MODE Customizations
-export const ELEVENLABS_API_KEY = "YOUR_ELEVENLABS_API_KEY";
-export const OPENAI_API_KEY = "YOUR_OPENAI_API_KEY";
+export const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY ?? "";
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "";

--- a/apps/demo/src/components/elevenlabs_agent/context.tsx
+++ b/apps/demo/src/components/elevenlabs_agent/context.tsx
@@ -11,7 +11,9 @@ import {
   VoiceChatState,
   VoiceChatConfig,
 } from "@heygen/liveavatar-web-sdk";
-import { API_URL } from "../../../app/api/secrets";
+
+// Client component: only NEXT_PUBLIC_* env vars reach the browser bundle.
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://api.liveavatar.com";
 
 export type ElevenLabsInboundEvent = {
   event_id: string;

--- a/apps/demo/src/liveavatar/context.tsx
+++ b/apps/demo/src/liveavatar/context.tsx
@@ -10,7 +10,9 @@ import {
   VoiceChatConfig,
 } from "@heygen/liveavatar-web-sdk";
 import { LiveAvatarSessionMessage, MessageSender } from "./types";
-import { API_URL } from "../../app/api/secrets";
+
+// Client component: only NEXT_PUBLIC_* env vars reach the browser bundle.
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://api.liveavatar.com";
 
 type LiveAvatarContextProps = {
   sessionRef: React.RefObject<LiveAvatarSession>;

--- a/apps/demo/vercel.json
+++ b/apps/demo/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter=demo"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,10 @@
         "DEFAULT_AVATAR_ID",
         "DEFAULT_VOICE_ID",
         "DEFAULT_CONTEXT_ID",
-        "DEFAULT_LANGUAGE"
+        "DEFAULT_LANGUAGE",
+        "IS_SANDBOX",
+        "ELEVENLABS_API_KEY",
+        "OPENAI_API_KEY"
       ]
     },
     "lint": {


### PR DESCRIPTION
- Read API key and session config from environment variables in apps/demo/app/api/secrets.ts (same export names, no route changes); sandbox mode stays the default unless IS_SANDBOX=false
- Use NEXT_PUBLIC_API_URL in the two client components that previously imported the server secrets module
- Add .env.example, vercel.json pinning the turbo monorepo build command, and README docs for configuration and Vercel deployment
- Allowlist new env vars in turbo.json build task


Claude-Session: https://claude.ai/code/session_01XYVRiqkGV2kUpkK2QAjGQ2

## Proposed changes

<!-- Provide a description of what is in the PR -->
